### PR TITLE
fix: charts tooltip theme color for darkmode

### DIFF
--- a/components/dashboard/charts/AlertsOverviewChart.tsx
+++ b/components/dashboard/charts/AlertsOverviewChart.tsx
@@ -74,6 +74,8 @@ export default function AlertsOverviewChart(props) {
               fontSize: "12px",
               textTransform: "capitalize",
               borderRadius: "6px",
+              background: "#000000",
+              color: "#ffffff",
             },
           },
           grid: {

--- a/components/dashboard/charts/SalesFunnelChart.tsx
+++ b/components/dashboard/charts/SalesFunnelChart.tsx
@@ -39,6 +39,20 @@ export default function SalesFunnelChart(props) {
         direction="horizontal"
         valueFormat=">-.4s"
         colors={{ scheme: "nivo" }}
+        theme={{
+          tooltip: {
+            chip: {
+              borderRadius: "9999px",
+            },
+            container: {
+              fontSize: "12px",
+              textTransform: "capitalize",
+              borderRadius: "6px",
+              background: "#000000",
+              color: "#ffffff",
+            },
+          },
+        }}
         borderWidth={20}
         borderColor={{ from: "color", modifiers: [] }}
         labelColor={{


### PR DESCRIPTION
## Description
The chart tooltip text visibility is affected in dark mode. Introduced a different bg and fg color for the charts to make the text suit for both themes (light and dark).

## What type of PR is this? (check all applicable)

- [ ] 💡 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

This PR fixes #12 

## Mobile & Desktop Screenshots/Recordings

Light Mode

![image_light](https://github.com/Codehagen/Dingify/assets/22556726/ba09d0a3-8b0e-4f8a-9eb5-ce10cb5259a2)

Dark Mode

![image_dark](https://github.com/Codehagen/Dingify/assets/22556726/9fa98960-f6a4-4744-bf11-61a61fdbc28e)

## Steps to QA

1. Change theme to light/dark mode
2. Hover on top of the graph and try to read the data

## Added to documentation?

- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
